### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_package_wheels.yml
+++ b/.github/workflows/build_and_package_wheels.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_distributions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-py/security/code-scanning/1](https://github.com/cyborginc/cyborgdb-py/security/code-scanning/1)

To address the issue, you should add a `permissions` key to restrict the `GITHUB_TOKEN` permissions for the `build_distributions` job to the minimum strictly necessary. In this context, `contents: read` is usually sufficient, because the job only checks out the code (which requires `contents: read` at most), runs builds, and uploads artifacts — no repository write access needed. To do this, add:
```yaml
permissions:
  contents: read
```
at the same indentation level as `runs-on` within the `build_distributions` job (after line 11 and before `steps`). No additional methods, imports, or other changes are needed; just adding this configuration is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
