### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test CyborgDB Python SDK
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-py/security/code-scanning/3](https://github.com/cyborginc/cyborgdb-py/security/code-scanning/3)

To fix the problem, we need to add an explicit `permissions` block to the workflow, restricting `GITHUB_TOKEN` permissions to the least set required for all jobs. As none of the jobs appear to require write access, the safest starting point is `contents: read`, which allows actions to clone and read repository contents. This block can be added at the top level of the workflow YAML (right after the `name:` block and before the `on:` block) to apply universally, unless any job later requires a more permissive or granular setting.

No additional libraries or methods are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
