### PR TITLE
add optional save functionality to generate_key function

### DIFF
--- a/cyborgdb/client/client.py
+++ b/cyborgdb/client/client.py
@@ -131,10 +131,12 @@ class Client:
         if key_path.exists():
             key_from_file = key_path.read_bytes()
             if len(key_from_file) == 32:
+                logger.warning(f"Loading existing index key from '{key_path}'.\nSaving keys is not recommended for production use.")
                 return key_from_file
         
         key = secrets.token_bytes(32)
         key_path.write_bytes(key)
+        logger.warning(f"Generated new index key and saved to '{key_path}'.\nSaving keys is not recommended for production use.")
         return key
 
     def list_indexes(self) -> List[str]:

--- a/cyborgdb/client/client.py
+++ b/cyborgdb/client/client.py
@@ -115,10 +115,13 @@ class Client:
             raise ValueError(error_msg)
 
     @staticmethod
-    def generate_key(save=False) -> bytes:
+    def generate_key(save: bool=False) -> bytes:
         """
         Generate a secure 32-byte key for use with CyborgDB indexes.
 
+        Args:
+            save (bool): If True, save the key to a file in the user's home directory
+                         for reuse. Not recommended for production use.
         Returns:
             bytes: A cryptographically secure 32-byte key.
         """

--- a/cyborgdb/client/client.py
+++ b/cyborgdb/client/client.py
@@ -115,7 +115,7 @@ class Client:
             raise ValueError(error_msg)
 
     @staticmethod
-    def generate_key(save: bool=False) -> bytes:
+    def generate_key(save: bool = False) -> bytes:
         """
         Generate a secure 32-byte key for use with CyborgDB indexes.
 
@@ -127,18 +127,22 @@ class Client:
         """
         if not save:
             return secrets.token_bytes(32)
-        
+
         key_path = Path.home() / ".cyborgdb" / "index_key"
         key_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         if key_path.exists():
             if key_path.stat().st_size == 32:
-                logger.warning(f"Loading existing index key from '{key_path}'.\nSaving keys is not recommended for production use.")
+                logger.warning(
+                    f"Loading existing index key from '{key_path}'.\nSaving keys is not recommended for production use."
+                )
                 return key_path.read_bytes()
-        
+
         key = secrets.token_bytes(32)
         key_path.write_bytes(key)
-        logger.warning(f"Generated new index key and saved to '{key_path}'.\nSaving keys is not recommended for production use.")
+        logger.warning(
+            f"Generated new index key and saved to '{key_path}'.\nSaving keys is not recommended for production use."
+        )
         return key
 
     def list_indexes(self) -> List[str]:

--- a/cyborgdb/client/client.py
+++ b/cyborgdb/client/client.py
@@ -4,6 +4,7 @@ CyborgDB REST Client
 This module provides a Python client for interacting with the CyborgDB REST API.
 """
 
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 import secrets
 import logging
@@ -114,14 +115,27 @@ class Client:
             raise ValueError(error_msg)
 
     @staticmethod
-    def generate_key() -> bytes:
+    def generate_key(save=False) -> bytes:
         """
         Generate a secure 32-byte key for use with CyborgDB indexes.
 
         Returns:
             bytes: A cryptographically secure 32-byte key.
         """
-        return secrets.token_bytes(32)
+        if not save:
+            return secrets.token_bytes(32)
+        
+        key_path = Path.home() / ".cyborgdb" / "index_key"
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        if key_path.exists():
+            key_from_file = key_path.read_bytes()
+            if len(key_from_file) == 32:
+                return key_from_file
+        
+        key = secrets.token_bytes(32)
+        key_path.write_bytes(key)
+        return key
 
     def list_indexes(self) -> List[str]:
         """

--- a/cyborgdb/client/client.py
+++ b/cyborgdb/client/client.py
@@ -129,10 +129,9 @@ class Client:
         key_path.parent.mkdir(parents=True, exist_ok=True)
         
         if key_path.exists():
-            key_from_file = key_path.read_bytes()
-            if len(key_from_file) == 32:
+            if key_path.stat().st_size == 32:
                 logger.warning(f"Loading existing index key from '{key_path}'.\nSaving keys is not recommended for production use.")
-                return key_from_file
+                return key_path.read_bytes()
         
         key = secrets.token_bytes(32)
         key_path.write_bytes(key)


### PR DESCRIPTION
This change to the `generate_key()` function adds the ability to set `save=true` as a function parameter which will then adjust the logic to look in `{home}/.cyborgdb/index_key` for a 32-byte encryption key. if no valid encryption key is found at that filepath, it will generate a new key and save it to that filepath.