### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_package_wheels.yml
+++ b/.github/workflows/build_and_package_wheels.yml
@@ -59,6 +59,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-py/security/code-scanning/13](https://github.com/cyborginc/cyborgdb-py/security/code-scanning/13)

Add an explicit `permissions` block for the `lint` job (or at workflow root). The smallest, safest change that does not alter behavior is to add job-level permissions under `lint` with `contents: read`, since checkout requires reading repository contents and linting itself needs no write scopes.

**Best single change in shown snippet:**
- File: `.github/workflows/build_and_package_wheels.yml`
- Region: `jobs.lint` (around lines 60–62)
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  directly under `runs-on` (or before it) in the `lint` job.

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
