### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_package_wheels.yml
+++ b/.github/workflows/build_and_package_wheels.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   compute_version:
     name: Compute Package Version


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-py/security/code-scanning/9](https://github.com/cyborginc/cyborgdb-py/security/code-scanning/9)

Add an explicit `permissions` block at the workflow root so every job gets a safe default (`contents: read`), while keeping existing per-job overrides (`test` has `id-token: write`) unchanged. This is the least intrusive and best single fix because it covers all current and future jobs that don’t declare permissions, without changing job behavior.

In `.github/workflows/build_and_package_wheels.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the `on:` trigger section (before `jobs:`). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
