### PR TITLE
move to text license for codeartifact support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools-scm[toml]>=6.2", "wheel"]
+requires = ["setuptools>=42,<77", "setuptools-scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Python Client SDK for CyborgDB: The Confidential Vector Database"
 readme = "README.md"
 requires-python = ">= 3.10"
-license = "MIT"
+license = { text = "MIT" }
 authors = [
     {name = "Cyborg Inc."}
 ]


### PR DESCRIPTION
I guess CodeArtifact doesn't support "Metadata 2.4" for python packages. setting `license = "MIT"` was added in 2.4 and is a shortcut for setting the license file to the MIT license. This change just sets the license text to "MIT" which is the old standard, but still supported and is required if we use CodeArtifact.